### PR TITLE
feat: add VirtualColumn highlight group usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,11 @@ require('davepinto/virtual-column').setup({
     enabled = true
 })
 ```
+
+Color change
+
+You can change column color via `VirtualColumn` highlight group:
+
+```vim
+  hi VirtualColumn guifg=#111111
+```

--- a/lua/virtual-column/init.lua
+++ b/lua/virtual-column/init.lua
@@ -11,7 +11,7 @@ local setup = function(options)
   vim.g.virtual_column_enabled = utils.ternily(options.enabled, true)
 
   vim.g.virtual_column_virtual_text = {
-    virt_text = {{utils.ternily(options.vert_char, "|")}},
+    virt_text = {{utils.ternily(options.vert_char, "|"), "VirtualColumn"}},
     virt_text_win_col = vim.g.virtual_column_column_number,
     hl_mode = "combine"
   }


### PR DESCRIPTION
A simple patch for the ability to change colors. (#2)

To change the color, define a `VirtualColumn` highlight group:
```vim
hi VirtualColumn guifg=#111111
```

Suggestion: if you're using [indentline](https://github.com/lukas-reineke/indent-blankline.nvim), you can link indent color with column color:
```vim
hi link VirtualColumn IndentBlanklineChar
```