### PR TITLE
hotfix/init.lua

### DIFF
--- a/lua/virtual-column/init.lua
+++ b/lua/virtual-column/init.lua
@@ -56,11 +56,10 @@ M.refresh = function()
     return
   end
 
+  local buffer = vim.api.nvim_get_current_buf()
   vim.api.nvim_buf_clear_namespace(buffer, vim.g.virtual_column_namespace, 0, -1)
 
   if vim.g.virtual_column_enabled then
-    local buffer = vim.api.nvim_get_current_buf()
-
     local buftype = vim.fn.getbufvar(buffer, '&buftype')
     local filetype = vim.fn.getbufvar(buffer, '&filetype')
 

--- a/lua/virtual-column/init.lua
+++ b/lua/virtual-column/init.lua
@@ -44,8 +44,8 @@ M.disable = function()
     return
   end
 
-  local bufnr = vim.api.nvim_get_current_buf()
-  vim.api.nvim_buf_clear_namespace(bufnr, vim.g.virtual_column_namespace, 0, -1)
+  local buffer = vim.api.nvim_get_current_buf()
+  vim.api.nvim_buf_clear_namespace(buffer, vim.g.virtual_column_namespace, 0, -1)
 end
 
 M.refresh = function()
@@ -56,30 +56,30 @@ M.refresh = function()
     return
   end
 
-  vim.api.nvim_buf_clear_namespace(bufnr, vim.g.virtual_column_namespace, 0, -1)
+  vim.api.nvim_buf_clear_namespace(buffer, vim.g.virtual_column_namespace, 0, -1)
 
   if vim.g.virtual_column_enabled then
-    local bufnr = vim.api.nvim_get_current_buf()
+    local buffer = vim.api.nvim_get_current_buf()
 
-    local buftype = vim.fn.getbufvar(bufnr, '&buftype')
-    local filetype = vim.fn.getbufvar(bufnr, '&filetype')
+    local buftype = vim.fn.getbufvar(buffer, '&buftype')
+    local filetype = vim.fn.getbufvar(buffer, '&filetype')
 
     if
-      vim.api.nvim_buf_is_valid(bufnr) and
-      vim.api.nvim_buf_is_loaded(bufnr) and
+      vim.api.nvim_buf_is_valid(buffer) and
+      vim.api.nvim_buf_is_loaded(buffer) and
       not utils.includes(vim.g.virtual_column_buftype_exclude, buftype) and
       not utils.includes(vim.g.virtual_column_filetype_exclude, filetype)
     then
-      local num_lines = vim.api.nvim_buf_line_count(bnr)
+      local num_lines = vim.api.nvim_buf_line_count(buffer)
 
       for i = 0,num_lines-1,1 do
 
         if
           vim.g.virtual_column_overlay or
-          #vim.api.nvim_buf_get_lines(bufnr, i, i+1, false)[1] <= vim.g.virtual_column_column_number
+          #vim.api.nvim_buf_get_lines(buffer, i, i+1, false)[1] <= vim.g.virtual_column_column_number
         then
           vim.schedule_wrap(vim.api.nvim_buf_set_extmark(
-              bufnr,
+              buffer,
               vim.g.virtual_column_namespace,
               i,
               -1,

--- a/lua/virtual-column/init.lua
+++ b/lua/virtual-column/init.lua
@@ -6,7 +6,7 @@ local setup = function(options)
     options = {}
   end
 
-  vim.g.virtual_column_column_number = utils.ternily(options.column_number, 80)
+  vim.g.virtual_column_column_number = utils.ternily(options.column_number - 1, 79)
   vim.g.virtual_column_overlay = utils.ternily(options.overlay, false)
   vim.g.virtual_column_enabled = utils.ternily(options.enabled, true)
   vim.g.virtual_column_buftype_exclude = utils.ternily(options.buftype_exclude, {})


### PR DESCRIPTION
On installing, I was receiving constant errors (both on open and on any edit). They were all related to line 59. I looked into it and noticed some issues:

- Line 59: variable `bufnr` was being initialized after its call, causing errors. Moved local bufnr call to before line 59.
- Line 73: variable was called `bnr`, with no such variable in the code. Changed this to `bufnr`.
- When compared to vim's internal `set colorcolumn`, the column with the "|" char being added was always 1 after what would be added by the aforementioned command. Now it lines up with the original internal command at the column number specified by the init settings.
- Variables were called `bufnr`, but `nvim_get_current_buf()` and other related functions return buffer handles, not numbers, so renamed for clarity-sake.

After making these changes, I was able to finally get it working. I cannot imagine how it could work before, given the issues on lines 59 and 73.